### PR TITLE
endless loop following self referential structs

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -429,6 +429,9 @@ func buildResolver(typ reflect.Type, field reflect.StructField, parent *Resolver
 			if !field.IsExported() {
 				continue
 			}
+			if field.Type == root.Type {
+				continue
+			}
 
 			child, err := buildResolver(field.Type, field, root)
 			if err != nil {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -248,6 +248,14 @@ func TestNew_WithNonStruct(t *testing.T) {
 	assert.ErrorContains(t, err, "non-struct type")
 }
 
+func TestNew_WithRecursion(t *testing.T) {
+	type RecursiveRef struct {
+		Loop *RecursiveRef
+	}
+	_, err := owl.New(RecursiveRef{})
+	assert.NoError(t, err)
+}
+
 func TestNew_ParsingDirectives_InvalidName(t *testing.T) {
 	resolver, err := owl.New(struct {
 		Invalid string `owl:"invalid/name"`


### PR DESCRIPTION
Support owl (i.e. httpin since v0.12.0) on some recursive structures, such as typical database models with parent references. Does not yet account for indirect references (loops back via another struct), but maybe that can be avoided in another way before overcomplicating this.