### PR TITLE
Fix bug when slice re-allocation on append causes parent-child references to override each other

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -422,8 +422,8 @@ func buildResolver(typ reflect.Type, field reflect.StructField, parent *Resolver
 			return nil, fmt.Errorf("parse directives (tag): %w", err)
 		}
 		root.Directives = directives
-		root.Path = append(root.Parent.Path, field.Name)
-		root.Index = append(root.Parent.Index, field.Index...)
+		root.Path = append(cloneSlice(root.Parent.Path), field.Name)
+		root.Index = append(cloneSlice(root.Parent.Index), field.Index...)
 	}
 
 	if typ.Kind() == reflect.Ptr {
@@ -533,5 +533,12 @@ func dereference(v reflect.Value) (reflect.Value, error) {
 	if v.IsNil() {
 		return v, errors.New("nil pointer")
 	}
+
 	return dereference(v.Elem())
+}
+
+func cloneSlice[S ~[]E, E any](slice S) S {
+	clone := make(S, 0, len(slice))
+	clone = append(clone, slice...)
+	return clone
 }


### PR DESCRIPTION
Hello!

In my project I have deeply embedded structures for my "get list of <something>" handlers that look something like this (but with a lot more fields):

```go
type StringFilter struct {
	Equals string `in:"query=filter.struct1.struct2.name.equals"`
	Not    string `in:"query=filter.struct1.struct2.name.not"`
}

type Struct2Filter struct {
	StringFilter
}

type Struct1Filter struct {
	Struct2Filter
}
```

I noticed that sometimes when I pass in the query `filter.struct1.struct2.name.not=bug`, I get all entities with the name "bug" instead.
After debugging, I noticed that some fields had `Resolver.Path = []string{"Struct1Filter", "Struct2Filter", "StringFilter", "Not"}`, but at the same time `Resolver.Directives = []*Directive{{Name: "query", Argv: []string{"filter.struct1.struct2.name.equals"}}}`

Cloning `Path` and `Index` resolved this bug, so I assume that underlying array was overridden by append in certain cases 